### PR TITLE
fix: Adjust Regex to Twitch commands to allow more words in the message

### DIFF
--- a/src/utils/regExp.ts
+++ b/src/utils/regExp.ts
@@ -1,4 +1,4 @@
 export module RegExpModule {
-	export const jolinesUser = /^!jolines @?[a-zA-Z0-9_]{4,25}$/
+	export const jolinesUser = /^!jolines @?[a-zA-Z0-9_]{4,25}(?:\s+\w+)*$/
 	export const alforUser = /^!(aflor|flor) @?[a-zA-Z0-9_]{4,25}(?:\s+\w+)*$/
 }

--- a/src/utils/regExp.ts
+++ b/src/utils/regExp.ts
@@ -1,4 +1,4 @@
 export module RegExpModule {
 	export const jolinesUser = /^!jolines @?[a-zA-Z0-9_]{4,25}$/
-	export const alforUser = /^!(aflor|flor) @?[a-zA-Z0-9_]{4,25}$/
+	export const alforUser = /^!(aflor|flor) @?[a-zA-Z0-9_]{4,25}(?:\s+\w+)*$/
 }


### PR DESCRIPTION
Hola!

El regex actual no permite mensajes con más de 2 palabras, por ejemplo `!aflor @snow_drive1 <3`, se ajusta regex para que ignore el mensaje restante después de validar las 2 primeras palabras

De igual forma para el comando `!jolines`

Feliz día