### PR TITLE
Add cronjobs services

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "awilix": "^8.0.1",
     "axios": "^1.3.3",
+    "cron": "^2.3.1",
     "cross-env": "^7.0.3",
     "dayjs": "^1.11.7",
     "dotenv": "^16.0.2",
@@ -35,6 +36,7 @@
     "vitest": "^0.30.1"
   },
   "devDependencies": {
+    "@types/cron": "^2.0.1",
     "@types/module-alias": "^2.0.1",
     "@types/node": "^18.7.18",
     "@types/tmi.js": "^1.8.3",

--- a/src/application/getUserJolines/index.ts
+++ b/src/application/getUserJolines/index.ts
@@ -13,7 +13,7 @@ export class GetUserJolines {
 
 	public async execute({ username, channelName }: GetUserJolinesCommand) {
 		const pig = this._emojiService.getRandomPig()
-		const user = await this._userRepository.findByUsernameAndChannel({ username, channel: channelName })
+		const user = await this._userRepository.findByUsernameAndChannel({ username, channelName })
 		const jolines = user?.jolines ?? 0
 		return new GetUserJolinesResponse({ username, jolines, pig })
 	}

--- a/src/application/getUsersImages.ts
+++ b/src/application/getUsersImages.ts
@@ -1,0 +1,38 @@
+import { Dependencies } from 'types/container'
+import { Image } from 'domain/image/Image'
+import { HelixUserData } from 'infrastructure/types/restHelixClient'
+
+export class GetUsersImages {
+	private _userRepository: Dependencies['userRepository']
+	private _imageRepository: Dependencies['imageRepository']
+	private _restHelixClient: Dependencies['restHelixClient']
+	private _dateService: Dependencies['dateService']
+
+	constructor({
+		userRepository,
+		imageRepository,
+		restHelixClient,
+		dateService,
+	}: Pick<Dependencies, 'userRepository' | 'imageRepository' | 'restHelixClient' | 'dateService'>) {
+		this._userRepository = userRepository
+		this._imageRepository = imageRepository
+		this._restHelixClient = restHelixClient
+		this._dateService = dateService
+	}
+
+	private _generateImage(userData: HelixUserData, currentDate: string) {
+		return new Image({
+			username: userData.login,
+			imageUrl: userData.profile_image_url,
+			updatedAt: currentDate,
+		})
+	}
+
+	public async execute() {
+		const currentDate = this._dateService.now()
+		const users = await this._userRepository.findKeys('users')
+		const usersData = await this._restHelixClient.getUsersData(users)
+		const images = usersData.map((user) => this._generateImage(user, currentDate))
+		await this._imageRepository.saveMany(images)
+	}
+}

--- a/src/application/incrementAflores/index.ts
+++ b/src/application/incrementAflores/index.ts
@@ -21,6 +21,8 @@ export class IncrementAflores {
 		// Get instances of the domain objects
 		const aflor = this._emojiService.getRandomAflor()
 		const user = await this._userRepository.findByUsername({ username: receiverName, collection: 'users' })
+		const weeklyUser = await this._userRepository.findByUsername({ username: receiverName, collection: 'weekly' })
+		const monthlyUser = await this._userRepository.findByUsername({ username: receiverName, collection: 'monthly' })
 		const channel = await this._userRepository.findByUsername({ username: channelName, collection: 'channels' })
 		const channelUser = await this._userRepository.findByUsernameAndChannel({
 			username: receiverName,
@@ -29,16 +31,22 @@ export class IncrementAflores {
 
 		// Create the domain objects if they don't exist
 		const userDomain = this._userGenerator.generateIfNotExists({ user, username: receiverName })
+		const weeklyUserDomain = this._userGenerator.generateIfNotExists({ user: weeklyUser, username: receiverName })
+		const monthlyUserDomain = this._userGenerator.generateIfNotExists({ user: monthlyUser, username: receiverName })
 		const channelDomain = this._userGenerator.generateIfNotExists({ user: channel, username: channelName })
 		const channelUserDomain = this._userGenerator.generateIfNotExists({ user: channelUser, username: receiverName })
 
 		// Increment aflores
 		userDomain.incrementAflores(aflor)
+		weeklyUserDomain.incrementAflores(aflor)
+		monthlyUserDomain.incrementAflores(aflor)
 		channelDomain.incrementAflores(aflor)
 		channelUserDomain.incrementAflores(aflor)
 
 		// Save the changes
 		await this._userRepository.saveByUsername({ user: userDomain, collection: 'users' })
+		await this._userRepository.saveByUsername({ user: weeklyUserDomain, collection: 'weekly' })
+		await this._userRepository.saveByUsername({ user: monthlyUserDomain, collection: 'monthly' })
 		await this._userRepository.saveByUsername({ user: channelDomain, collection: 'channels' })
 		await this._userRepository.saveByUsernameAndChannel({ user: channelUserDomain, channel: channelName })
 

--- a/src/application/incrementAflores/index.ts
+++ b/src/application/incrementAflores/index.ts
@@ -24,10 +24,7 @@ export class IncrementAflores {
 		const weeklyUser = await this._userRepository.findByUsername({ username: receiverName, collection: 'weekly' })
 		const monthlyUser = await this._userRepository.findByUsername({ username: receiverName, collection: 'monthly' })
 		const channel = await this._userRepository.findByUsername({ username: channelName, collection: 'channels' })
-		const channelUser = await this._userRepository.findByUsernameAndChannel({
-			username: receiverName,
-			channel: channelName,
-		})
+		const channelUser = await this._userRepository.findByUsernameAndChannel({ username: receiverName, channelName })
 
 		// Create the domain objects if they don't exist
 		const userDomain = this._userGenerator.generateIfNotExists({ user, username: receiverName })
@@ -48,7 +45,7 @@ export class IncrementAflores {
 		await this._userRepository.saveByUsername({ user: weeklyUserDomain, collection: 'weekly' })
 		await this._userRepository.saveByUsername({ user: monthlyUserDomain, collection: 'monthly' })
 		await this._userRepository.saveByUsername({ user: channelDomain, collection: 'channels' })
-		await this._userRepository.saveByUsernameAndChannel({ user: channelUserDomain, channel: channelName })
+		await this._userRepository.saveByUsernameAndChannel({ user: channelUserDomain, channelName })
 
 		// Return the response
 		return new IncrementAfloresResponse({ gifterName, receiverName, aflor })

--- a/src/application/incrementJolines/index.ts
+++ b/src/application/incrementJolines/index.ts
@@ -16,7 +16,7 @@ export class IncrementJolines {
 		const weeklyUser = await this._userRepository.findByUsername({ username, collection: 'weekly' })
 		const monthlyUser = await this._userRepository.findByUsername({ username, collection: 'monthly' })
 		const channel = await this._userRepository.findByUsername({ username: channelName, collection: 'channels' })
-		const channelUser = await this._userRepository.findByUsernameAndChannel({ username, channel: channelName })
+		const channelUser = await this._userRepository.findByUsernameAndChannel({ username, channelName })
 
 		// Create the domain objects if they don't exist
 		const userDomain = this._userGenerator.generateIfNotExists({ user, username })
@@ -37,6 +37,6 @@ export class IncrementJolines {
 		await this._userRepository.saveByUsername({ user: weeklyUserDomain, collection: 'weekly' })
 		await this._userRepository.saveByUsername({ user: monthlyUserDomain, collection: 'monthly' })
 		await this._userRepository.saveByUsername({ user: channelDomain, collection: 'channels' })
-		await this._userRepository.saveByUsernameAndChannel({ user: channelUserDomain, channel: channelName })
+		await this._userRepository.saveByUsernameAndChannel({ user: channelUserDomain, channelName })
 	}
 }

--- a/src/application/incrementJolines/index.ts
+++ b/src/application/incrementJolines/index.ts
@@ -13,21 +13,29 @@ export class IncrementJolines {
 	public async execute({ username, channelName }: IncrementJolinesCommand) {
 		// Get instances of the domain objects
 		const user = await this._userRepository.findByUsername({ username, collection: 'users' })
+		const weeklyUser = await this._userRepository.findByUsername({ username, collection: 'weekly' })
+		const monthlyUser = await this._userRepository.findByUsername({ username, collection: 'monthly' })
 		const channel = await this._userRepository.findByUsername({ username: channelName, collection: 'channels' })
 		const channelUser = await this._userRepository.findByUsernameAndChannel({ username, channel: channelName })
 
 		// Create the domain objects if they don't exist
 		const userDomain = this._userGenerator.generateIfNotExists({ user, username })
+		const weeklyUserDomain = this._userGenerator.generateIfNotExists({ user: weeklyUser, username })
+		const monthlyUserDomain = this._userGenerator.generateIfNotExists({ user: monthlyUser, username })
 		const channelDomain = this._userGenerator.generateIfNotExists({ user: channel, username: channelName })
 		const channelUserDomain = this._userGenerator.generateIfNotExists({ user: channelUser, username })
 
 		// Increment jolines
 		userDomain.incrementJolines()
+		weeklyUserDomain.incrementJolines()
+		monthlyUserDomain.incrementJolines()
 		channelDomain.incrementJolines()
 		channelUserDomain.incrementJolines()
 
 		// Save the changes
 		await this._userRepository.saveByUsername({ user: userDomain, collection: 'users' })
+		await this._userRepository.saveByUsername({ user: weeklyUserDomain, collection: 'weekly' })
+		await this._userRepository.saveByUsername({ user: monthlyUserDomain, collection: 'monthly' })
 		await this._userRepository.saveByUsername({ user: channelDomain, collection: 'channels' })
 		await this._userRepository.saveByUsernameAndChannel({ user: channelUserDomain, channel: channelName })
 	}

--- a/src/application/resetRanking/index.ts
+++ b/src/application/resetRanking/index.ts
@@ -1,0 +1,14 @@
+import { Dependencies } from 'types/container'
+import { ResetRankingCommand } from './resetRankingCommand'
+
+export class ResetRanking {
+	private _userRepository: Dependencies['userRepository']
+
+	constructor({ userRepository }: Pick<Dependencies, 'userRepository'>) {
+		this._userRepository = userRepository
+	}
+
+	public async execute({ collection }: ResetRankingCommand) {
+		this._userRepository.delete({ collection })
+	}
+}

--- a/src/application/resetRanking/resetRankingCommand.ts
+++ b/src/application/resetRanking/resetRankingCommand.ts
@@ -1,0 +1,9 @@
+import { RankingCollection, ResetRankingCommandConstructor } from 'application/types/resetRanking'
+
+export class ResetRankingCommand implements ResetRankingCommandConstructor {
+	public collection: RankingCollection
+
+	constructor({ collection }: ResetRankingCommandConstructor) {
+		this.collection = collection
+	}
+}

--- a/src/application/types/resetRanking.d.ts
+++ b/src/application/types/resetRanking.d.ts
@@ -1,0 +1,5 @@
+export type RankingCollection = 'weekly' | 'monthly'
+
+export interface ResetRankingCommandConstructor {
+	collection: RankingCollection
+}

--- a/src/container.ts
+++ b/src/container.ts
@@ -28,6 +28,7 @@ import { GetChannelJolines } from 'application/getChannelJolines'
 import { GetUserJolines } from 'application/getUserJolines'
 import { IncrementAflores } from 'application/incrementAflores'
 import { IncrementJolines } from 'application/incrementJolines'
+import { ResetRanking } from 'application/resetRanking'
 
 import type { Dependencies } from 'types/container'
 
@@ -71,6 +72,7 @@ container.register({
 	getUserJolines: asClass(GetUserJolines),
 	incrementAflores: asClass(IncrementAflores),
 	incrementJolines: asClass(IncrementJolines),
+	resetRanking: asClass(ResetRanking),
 })
 
 export { container }

--- a/src/container.ts
+++ b/src/container.ts
@@ -24,6 +24,7 @@ import { FirebaseHandler } from 'infrastructure/persistance/firebase/dbHandler'
 import { userDocumentParser } from 'infrastructure/persistance/firebase/user/userDocumentParser'
 import { UserRepository } from 'infrastructure/persistance/firebase/user/userRepository'
 import { imageDocumentParser } from 'infrastructure/persistance/firebase/image/imageDocumentParser'
+import { ImageRepository } from 'infrastructure/persistance/firebase/image/imageRepository'
 
 import { GetChannelAflores } from 'application/getChannelAflores'
 import { GetChannelJolines } from 'application/getChannelJolines'
@@ -70,6 +71,7 @@ container.register({
 	userDocumentParser: asFunction(userDocumentParser),
 	userRepository: asClass(UserRepository),
 	imageDocumentParser: asFunction(imageDocumentParser),
+	imageRepository: asClass(ImageRepository),
 
 	// Use cases
 	getChannelAflores: asClass(GetChannelAflores),

--- a/src/container.ts
+++ b/src/container.ts
@@ -32,6 +32,7 @@ import { GetUserJolines } from 'application/getUserJolines'
 import { IncrementAflores } from 'application/incrementAflores'
 import { IncrementJolines } from 'application/incrementJolines'
 import { ResetRanking } from 'application/resetRanking'
+import { GetUsersImages } from 'application/getUsersImages'
 
 import type { Dependencies } from 'types/container'
 
@@ -80,6 +81,7 @@ container.register({
 	incrementAflores: asClass(IncrementAflores),
 	incrementJolines: asClass(IncrementJolines),
 	resetRanking: asClass(ResetRanking),
+	getUsersImages: asClass(GetUsersImages),
 })
 
 export { container }

--- a/src/container.ts
+++ b/src/container.ts
@@ -9,9 +9,11 @@ import { AxiosHttpClient } from 'infrastructure/services/axiosHttpClient'
 import { RestHelixClient } from 'infrastructure/services/restHelixClient'
 import { CommandValidator } from 'infrastructure/services/commandValidator'
 import { TextParser } from 'infrastructure/services/textParser'
+
 import { FirebaseHandler } from 'infrastructure/persistance/firebase/dbHandler'
 import { userDocumentParser } from 'infrastructure/persistance/firebase/user/userDocumentParser'
 import { UserRepository } from 'infrastructure/persistance/firebase/user/userRepository'
+import { imageDocumentParser } from 'infrastructure/persistance/firebase/image/imageDocumentParser'
 
 import { GetChannelAflores } from 'application/getChannelAflores'
 import { GetChannelJolines } from 'application/getChannelJolines'
@@ -26,17 +28,27 @@ const container = createContainer<Dependencies>({
 })
 
 container.register({
+	// Values
 	axios: asValue(axios),
+
+	// Domain services
 	emojiService: asClass(EmojiService).singleton(),
 	userGenerator: asClass(UserGeneratorService),
+
+	// Infrastructure services
 	afordibot: asClass(AfordiBot).singleton(),
 	httpClient: asClass(AxiosHttpClient),
 	restHelixClient: asClass(RestHelixClient),
 	commandValidator: asClass(CommandValidator),
 	textParser: asClass(TextParser),
+
+	// Persistance
 	dbHandler: asClass(FirebaseHandler).singleton(),
 	userDocumentParser: asFunction(userDocumentParser),
 	userRepository: asClass(UserRepository),
+	imageDocumentParser: asFunction(imageDocumentParser),
+
+	// Use cases
 	getChannelAflores: asClass(GetChannelAflores),
 	getChannelJolines: asClass(GetChannelJolines),
 	getUserJolines: asClass(GetUserJolines),

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,9 +1,11 @@
 import { createContainer, InjectionMode, asValue, asClass, asFunction } from 'awilix'
+
 import axios from 'axios'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
+import { CronJob } from 'cron'
 
 import { DateService } from 'domain/services/date'
 import { EmojiService } from 'domain/services/emoji'
@@ -42,6 +44,7 @@ container.register({
 	// Values
 	axios: asValue(axios),
 	dayjs: asValue(dayjs),
+	CronJob: asValue(CronJob),
 
 	// Domain services
 	dateService: asClass(DateService).singleton(),

--- a/src/container.ts
+++ b/src/container.ts
@@ -5,6 +5,7 @@ import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 
+import { DateService } from 'domain/services/date'
 import { EmojiService } from 'domain/services/emoji'
 import { UserGeneratorService } from 'domain/services/userGenerator'
 
@@ -42,6 +43,7 @@ container.register({
 	dayjs: asValue(dayjs),
 
 	// Domain services
+	dateService: asClass(DateService).singleton(),
 	emojiService: asClass(EmojiService).singleton(),
 	userGenerator: asClass(UserGeneratorService),
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,5 +1,9 @@
 import { createContainer, InjectionMode, asValue, asClass, asFunction } from 'awilix'
 import axios from 'axios'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 
 import { EmojiService } from 'domain/services/emoji'
 import { UserGeneratorService } from 'domain/services/userGenerator'
@@ -23,6 +27,11 @@ import { IncrementJolines } from 'application/incrementJolines'
 
 import type { Dependencies } from 'types/container'
 
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
+dayjs.tz.setDefault('Europe/Madrid')
+
 const container = createContainer<Dependencies>({
 	injectionMode: InjectionMode.PROXY,
 })
@@ -30,6 +39,7 @@ const container = createContainer<Dependencies>({
 container.register({
 	// Values
 	axios: asValue(axios),
+	dayjs: asValue(dayjs),
 
 	// Domain services
 	emojiService: asClass(EmojiService).singleton(),

--- a/src/container.ts
+++ b/src/container.ts
@@ -11,6 +11,7 @@ import { UserGeneratorService } from 'domain/services/userGenerator'
 
 import { AfordiBot } from 'infrastructure/irc/afordibot'
 import { AxiosHttpClient } from 'infrastructure/services/axiosHttpClient'
+import { CronService } from 'infrastructure/services/cron'
 import { RestHelixClient } from 'infrastructure/services/restHelixClient'
 import { CommandValidator } from 'infrastructure/services/commandValidator'
 import { TextParser } from 'infrastructure/services/textParser'
@@ -50,6 +51,7 @@ container.register({
 	// Infrastructure services
 	afordibot: asClass(AfordiBot).singleton(),
 	httpClient: asClass(AxiosHttpClient),
+	cronService: asClass(CronService).singleton(),
 	restHelixClient: asClass(RestHelixClient),
 	commandValidator: asClass(CommandValidator),
 	textParser: asClass(TextParser),

--- a/src/container.ts
+++ b/src/container.ts
@@ -12,6 +12,8 @@ import { EmojiService } from 'domain/services/emoji'
 import { UserGeneratorService } from 'domain/services/userGenerator'
 
 import { AfordiBot } from 'infrastructure/irc/afordibot'
+import { CronJobs } from 'src/infrastructure/cron/cronJobs'
+
 import { AxiosHttpClient } from 'infrastructure/services/axiosHttpClient'
 import { CronService } from 'infrastructure/services/cron'
 import { RestHelixClient } from 'infrastructure/services/restHelixClient'
@@ -52,8 +54,11 @@ container.register({
 	emojiService: asClass(EmojiService).singleton(),
 	userGenerator: asClass(UserGeneratorService),
 
-	// Infrastructure services
+	// Entry points
 	afordibot: asClass(AfordiBot).singleton(),
+	cronJobs: asClass(CronJobs).singleton(),
+
+	// Infrastructure services
 	httpClient: asClass(AxiosHttpClient),
 	cronService: asClass(CronService).singleton(),
 	restHelixClient: asClass(RestHelixClient),

--- a/src/domain/image/Image.ts
+++ b/src/domain/image/Image.ts
@@ -1,0 +1,47 @@
+import { InvalidImageError, InvalidImageMessages } from './errors/invalidImageError'
+import { ImageEntity } from 'domain/types/Image'
+
+export class Image implements ImageEntity {
+	private _username: string
+	private _imageUrl: string
+	private _updatedAt: string
+
+	constructor({ username, imageUrl, updatedAt }: ImageEntity) {
+		this._assertUsername(username)
+		this._assertImageUrl(imageUrl)
+		this._assertUpdatedAt(updatedAt)
+		this._username = username
+		this._imageUrl = imageUrl
+		this._updatedAt = updatedAt
+	}
+
+	get username(): string {
+		return this._username
+	}
+
+	get imageUrl(): string {
+		return this._imageUrl
+	}
+
+	get updatedAt(): string {
+		return this._updatedAt
+	}
+
+	private _assertUsername(username: string) {
+		if (typeof username !== 'string' || username.length < 4) {
+			throw new InvalidImageError(InvalidImageMessages.INVALID_USERNAME)
+		}
+	}
+
+	private _assertImageUrl(imageUrl: string) {
+		if (typeof imageUrl !== 'string') {
+			throw new InvalidImageError(InvalidImageMessages.INVALID_IMAGE_URL)
+		}
+	}
+
+	private _assertUpdatedAt(updatedAt: string) {
+		if (typeof updatedAt !== 'string' || updatedAt.length !== 8) {
+			throw new InvalidImageError(InvalidImageMessages.INVALID_UPDATED_AT)
+		}
+	}
+}

--- a/src/domain/image/errors/invalidImageError.ts
+++ b/src/domain/image/errors/invalidImageError.ts
@@ -1,0 +1,11 @@
+export class InvalidImageError extends Error {
+	constructor(message: string) {
+		super(message)
+	}
+}
+
+export enum InvalidImageMessages {
+	INVALID_USERNAME = 'Property "username" is required and must be a string with at least 4 characters',
+	INVALID_IMAGE_URL = 'Property "imageUrl" is required and must be a string',
+	INVALID_UPDATED_AT = 'Property "updatedAt" is required and must be a string with the format "DDMMYYYY"',
+}

--- a/src/domain/services/date.ts
+++ b/src/domain/services/date.ts
@@ -1,0 +1,23 @@
+import { Dependencies } from 'types/container'
+
+export class DateService {
+	private FORMAT = 'DDMMYYYY'
+	private _dayjs: Dependencies['dayjs']
+
+	constructor({ dayjs }: Pick<Dependencies, 'dayjs'>) {
+		this._dayjs = dayjs
+	}
+
+	private _parse(date: string) {
+		return this._dayjs(date, this.FORMAT)
+	}
+
+	public now() {
+		return this._dayjs().format(this.FORMAT)
+	}
+
+	public isWeeklyOutdated(date: string) {
+		const limitDate = this._dayjs().subtract(7, 'day')
+		return this._parse(date).isBefore(limitDate)
+	}
+}

--- a/src/domain/services/date.ts
+++ b/src/domain/services/date.ts
@@ -8,16 +8,7 @@ export class DateService {
 		this._dayjs = dayjs
 	}
 
-	private _parse(date: string) {
-		return this._dayjs(date, this.FORMAT)
-	}
-
 	public now() {
 		return this._dayjs().format(this.FORMAT)
-	}
-
-	public isWeeklyOutdated(date: string) {
-		const limitDate = this._dayjs().subtract(7, 'day')
-		return this._parse(date).isBefore(limitDate)
 	}
 }

--- a/src/domain/types/Image.d.ts
+++ b/src/domain/types/Image.d.ts
@@ -1,0 +1,5 @@
+export interface ImageEntity {
+	username: string
+	imageUrl: string
+	updatedAt: string
+}

--- a/src/domain/user/User.ts
+++ b/src/domain/user/User.ts
@@ -1,4 +1,4 @@
-import { InvalidUserError, INVALID_USERNAME, INVALID_JOLINES, INVALID_AFLORES } from './errors/invalidUserError'
+import { InvalidUserError, InvalidUserMessages } from './errors/invalidUserError'
 import { AflorValue } from 'domain/types/Aflor'
 import { UserEntity } from 'domain/types/User'
 import { Aflor } from 'domain/types/Emoji'
@@ -46,19 +46,19 @@ export class User implements UserEntity {
 
 	private _assertUsername(username: string) {
 		if (typeof username !== 'string' || username.length < 4) {
-			throw new InvalidUserError(INVALID_USERNAME)
+			throw new InvalidUserError(InvalidUserMessages.INVALID_USERNAME)
 		}
 	}
 
 	private _assertJolines(jolines: number) {
 		if (!this._isPositiveInteger(jolines)) {
-			throw new InvalidUserError(INVALID_JOLINES)
+			throw new InvalidUserError(InvalidUserMessages.INVALID_JOLINES)
 		}
 	}
 
 	private _assertAflores(aflores: AflorValue) {
 		if (typeof aflores !== 'object' || !this._isPositiveInteger(aflores.total)) {
-			throw new InvalidUserError(INVALID_AFLORES)
+			throw new InvalidUserError(InvalidUserMessages.INVALID_AFLORES)
 		}
 	}
 

--- a/src/domain/user/errors/invalidUserError.ts
+++ b/src/domain/user/errors/invalidUserError.ts
@@ -4,8 +4,8 @@ export class InvalidUserError extends Error {
 	}
 }
 
-export const INVALID_USERNAME = 'Property "username" is required and must be a string with at least 4 characters'
-export const INVALID_JOLINES =
-	'Property "jolines" is required and must be a positive integer number equal or greater than 0'
-export const INVALID_AFLORES =
-	'Property "aflores" is required, must be an object and must have a "total" property as a positive integer number equal or greater than 0'
+export enum InvalidUserMessages {
+	INVALID_USERNAME = 'Property "username" is required and must be a string with at least 4 characters',
+	INVALID_JOLINES = 'Property "jolines" is required and must be a positive integer number equal or greater than 0',
+	INVALID_AFLORES = 'Property "aflores" is required, must be an object and must have a "total" property as a positive integer number equal or greater than 0',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,7 @@ import 'module-alias/register'
 import { container } from 'src/container'
 
 const afordibot = container.resolve('afordibot')
+const cronJobs = container.resolve('cronJobs')
+
 afordibot.connect()
+cronJobs.start()

--- a/src/infrastructure/cron/cronJobs.ts
+++ b/src/infrastructure/cron/cronJobs.ts
@@ -11,6 +11,17 @@ export class CronJobs {
 		this._cronService = cronService
 	}
 
+	private _getUsersImages() {
+		return async () => {
+			try {
+				await container.resolve('getUsersImages').execute()
+			} catch (error) {
+				// TODO - add error handling
+				console.log(error)
+			}
+		}
+	}
+
 	private _resetRanking(collection: RankingCollection) {
 		return async () => {
 			try {
@@ -24,6 +35,7 @@ export class CronJobs {
 	}
 
 	public start() {
+		this._cronService.weekly(this._getUsersImages())
 		this._cronService.weekly(this._resetRanking('weekly'))
 		this._cronService.monthly(this._resetRanking('monthly'))
 	}

--- a/src/infrastructure/cron/cronJobs.ts
+++ b/src/infrastructure/cron/cronJobs.ts
@@ -1,0 +1,30 @@
+import { container } from 'src/container'
+import { Dependencies } from 'types/container'
+
+import { ResetRankingCommand } from 'application/resetRanking/resetRankingCommand'
+import { RankingCollection } from 'application/types/resetRanking'
+
+export class CronJobs {
+	private _cronService: Dependencies['cronService']
+
+	constructor({ cronService }: Pick<Dependencies, 'cronService'>) {
+		this._cronService = cronService
+	}
+
+	private _resetRanking(collection: RankingCollection) {
+		return async () => {
+			try {
+				const command = new ResetRankingCommand({ collection })
+				await container.resolve('resetRanking').execute(command)
+			} catch (error) {
+				// TODO - add error handling
+				console.log(error)
+			}
+		}
+	}
+
+	public start() {
+		this._cronService.weekly(this._resetRanking('weekly'))
+		this._cronService.monthly(this._resetRanking('monthly'))
+	}
+}

--- a/src/infrastructure/persistance/firebase/common/baseRepository.ts
+++ b/src/infrastructure/persistance/firebase/common/baseRepository.ts
@@ -25,4 +25,13 @@ export class BaseRepository {
 			throw new Error(error)
 		}
 	}
+
+	protected async _delete(collection: string) {
+		const db = this._dbHandler.getInstance()
+		try {
+			await db.ref(collection).remove()
+		} catch (error: any) {
+			throw new Error(error)
+		}
+	}
 }

--- a/src/infrastructure/persistance/firebase/image/imageDocumentParser.ts
+++ b/src/infrastructure/persistance/firebase/image/imageDocumentParser.ts
@@ -1,0 +1,21 @@
+import { ImageDocumentParser } from 'infrastructure/types/imageRepository'
+import { Image } from 'domain/image/Image'
+
+export const imageDocumentParser = (): ImageDocumentParser => {
+	return {
+		toDomain: ({ username, imageUrl, updatedAt }) => {
+			return new Image({
+				username,
+				imageUrl,
+				updatedAt,
+			})
+		},
+		toDocument: ({ username, imageUrl, updatedAt }) => {
+			return {
+				username,
+				imageUrl,
+				updatedAt,
+			}
+		},
+	}
+}

--- a/src/infrastructure/persistance/firebase/image/imageRepository.ts
+++ b/src/infrastructure/persistance/firebase/image/imageRepository.ts
@@ -10,10 +10,11 @@ export class ImageRepository extends BaseRepository {
 
 	constructor({
 		dbHandler,
+		httpClient,
 		dateService,
 		imageDocumentParser,
-	}: Pick<Dependencies, 'dbHandler' | 'dateService' | 'imageDocumentParser'>) {
-		super({ dbHandler })
+	}: Pick<Dependencies, 'dbHandler' | 'httpClient' | 'dateService' | 'imageDocumentParser'>) {
+		super({ dbHandler, httpClient })
 		this._dateService = dateService
 		this._imageDocumentParser = imageDocumentParser
 	}

--- a/src/infrastructure/persistance/firebase/image/imageRepository.ts
+++ b/src/infrastructure/persistance/firebase/image/imageRepository.ts
@@ -1,0 +1,38 @@
+import { Dependencies } from 'types/container'
+import { BaseRepository } from '../common/baseRepository'
+import { ImagesDocument } from 'infrastructure/types/imageRepository'
+import { ImageEntity } from 'domain/types/Image'
+import { Image } from 'src/domain/image/Image'
+
+export class ImageRepository extends BaseRepository {
+	private _dateService: Dependencies['dateService']
+	private _imageDocumentParser: Dependencies['imageDocumentParser']
+
+	constructor({
+		dbHandler,
+		dateService,
+		imageDocumentParser,
+	}: Pick<Dependencies, 'dbHandler' | 'dateService' | 'imageDocumentParser'>) {
+		super({ dbHandler })
+		this._dateService = dateService
+		this._imageDocumentParser = imageDocumentParser
+	}
+
+	private _filterOutdated(images: Image[], image: ImageEntity) {
+		const isOutDated = this._dateService.isWeeklyOutdated(image.updatedAt)
+		if (isOutDated) images.push(this._imageDocumentParser.toDomain(image))
+		return images
+	}
+
+	public async findOutdated() {
+		try {
+			const document = await this._find<ImagesDocument>('images')
+			if (!document) return []
+			const images: ImageEntity[] = Object.values(document)
+			const outdatedImages = images.reduce<Image[]>(this._filterOutdated, [])
+			return outdatedImages
+		} catch (error: any) {
+			throw new Error(error)
+		}
+	}
+}

--- a/src/infrastructure/persistance/firebase/user/userDocumentParser.ts
+++ b/src/infrastructure/persistance/firebase/user/userDocumentParser.ts
@@ -1,5 +1,5 @@
 import { User } from 'domain/user/User'
-import { UserDocumentParser } from 'infrastructure/types/firebase'
+import { UserDocumentParser } from 'infrastructure/types/userRepository'
 
 export const userDocumentParser = (): UserDocumentParser => {
 	return {

--- a/src/infrastructure/persistance/firebase/user/userRepository.ts
+++ b/src/infrastructure/persistance/firebase/user/userRepository.ts
@@ -7,7 +7,7 @@ import {
 	SaveByUsername,
 	SaveByUsernameAndChannel,
 	UserCollection,
-} from 'infrastructure/types/firebase'
+} from 'infrastructure/types/userRepository'
 
 export class UserRepository extends BaseRepository {
 	private _userDocumentParser: Dependencies['userDocumentParser']

--- a/src/infrastructure/persistance/firebase/user/userRepository.ts
+++ b/src/infrastructure/persistance/firebase/user/userRepository.ts
@@ -6,6 +6,7 @@ import {
 	FindByUsernameAndChannel,
 	SaveByUsername,
 	SaveByUsernameAndChannel,
+	UserCollection,
 } from 'infrastructure/types/firebase'
 
 export class UserRepository extends BaseRepository {
@@ -49,6 +50,14 @@ export class UserRepository extends BaseRepository {
 			const { username, ...data } = this._userDocumentParser.toDocument(user)
 			const collection = `channels-users/${channelName}/${username}`
 			await this._save(collection, data)
+		} catch (error: any) {
+			throw new Error(error)
+		}
+	}
+
+	public async delete({ collection }: UserCollection) {
+		try {
+			await this._delete(collection)
 		} catch (error: any) {
 			throw new Error(error)
 		}

--- a/src/infrastructure/persistance/firebase/user/userRepository.ts
+++ b/src/infrastructure/persistance/firebase/user/userRepository.ts
@@ -25,9 +25,9 @@ export class UserRepository extends BaseRepository {
 		}
 	}
 
-	public async findByUsernameAndChannel({ username, channel }: FindByUsernameAndChannel) {
+	public async findByUsernameAndChannel({ username, channelName }: FindByUsernameAndChannel) {
 		try {
-			const collection = `channels-users/${channel}/${username}`
+			const collection = `channels-users/${channelName}/${username}`
 			const userData = await this._find<Omit<UserEntity, 'username'>>(collection)
 			return userData && this._userDocumentParser.toDomain({ username, ...userData })
 		} catch (error: any) {
@@ -44,10 +44,10 @@ export class UserRepository extends BaseRepository {
 		}
 	}
 
-	public async saveByUsernameAndChannel({ user, channel }: SaveByUsernameAndChannel) {
+	public async saveByUsernameAndChannel({ user, channelName }: SaveByUsernameAndChannel) {
 		try {
 			const { username, ...data } = this._userDocumentParser.toDocument(user)
-			const collection = `channels-users/${channel}/${username}`
+			const collection = `channels-users/${channelName}/${username}`
 			await this._save(collection, data)
 		} catch (error: any) {
 			throw new Error(error)

--- a/src/infrastructure/persistance/firebase/user/userRepository.ts
+++ b/src/infrastructure/persistance/firebase/user/userRepository.ts
@@ -12,8 +12,12 @@ import {
 export class UserRepository extends BaseRepository {
 	private _userDocumentParser: Dependencies['userDocumentParser']
 
-	constructor({ dbHandler, userDocumentParser }: Pick<Dependencies, 'dbHandler' | 'userDocumentParser'>) {
-		super({ dbHandler })
+	constructor({
+		dbHandler,
+		httpClient,
+		userDocumentParser,
+	}: Pick<Dependencies, 'dbHandler' | 'httpClient' | 'userDocumentParser'>) {
+		super({ dbHandler, httpClient })
 		this._userDocumentParser = userDocumentParser
 	}
 

--- a/src/infrastructure/services/cron.ts
+++ b/src/infrastructure/services/cron.ts
@@ -1,0 +1,20 @@
+import { CronJob, CronCommand } from 'cron'
+import { CronTime } from 'infrastructure/types/cron'
+
+export class CronService {
+	private _ON_COMPLETE = null
+	private _START_NOW = true
+	private _WEEKLY = '0 0 * * 1'
+	private _MONTHLY = '0 0 1 * *'
+
+	private _cronJob(command: CronTime, onTick: CronCommand) {
+		return new CronJob(command, onTick, this._ON_COMPLETE, this._START_NOW)
+	}
+	public weekly(onTick: CronCommand) {
+		return this._cronJob(this._WEEKLY, onTick)
+	}
+
+	public monthly(onTick: CronCommand) {
+		return this._cronJob(this._MONTHLY, onTick)
+	}
+}

--- a/src/infrastructure/services/cron.ts
+++ b/src/infrastructure/services/cron.ts
@@ -1,14 +1,20 @@
-import { CronJob, CronCommand } from 'cron'
+import { CronCommand } from 'cron'
 import { CronTime } from 'infrastructure/types/cron'
+import { Dependencies } from 'types/container'
 
 export class CronService {
+	private _CronJob: Dependencies['CronJob']
 	private _ON_COMPLETE = null
 	private _START_NOW = true
 	private _WEEKLY = '0 0 * * 1'
 	private _MONTHLY = '0 0 1 * *'
 
+	constructor({ CronJob }: Pick<Dependencies, 'CronJob'>) {
+		this._CronJob = CronJob
+	}
+
 	private _cronJob(command: CronTime, onTick: CronCommand) {
-		return new CronJob(command, onTick, this._ON_COMPLETE, this._START_NOW)
+		return new this._CronJob(command, onTick, this._ON_COMPLETE, this._START_NOW)
 	}
 	public weekly(onTick: CronCommand) {
 		return this._cronJob(this._WEEKLY, onTick)

--- a/src/infrastructure/services/restHelixClient.ts
+++ b/src/infrastructure/services/restHelixClient.ts
@@ -15,9 +15,9 @@ export class RestHelixClient {
 		return token.access_token
 	}
 
-	public async getUserImage(username: string) {
+	public async getUsersData(usernames: string[]) {
 		const accessToken = await this._getHelixToken()
-		const url = `https://api.twitch.tv/helix/users?login=${username}`
+		const url = `https://api.twitch.tv/helix/users?login=${usernames.join('&login=')}`
 		const options = {
 			headers: {
 				Authorization: `Bearer ${accessToken}`,
@@ -26,7 +26,6 @@ export class RestHelixClient {
 			},
 		}
 		const { data } = await this._httpClient.get<{ data: HelixUserData[] }>({ url, options })
-		if (data.length === 0) return null
-		return data[0].profile_image_url
+		return data
 	}
 }

--- a/src/infrastructure/types/baseRepository.d.ts
+++ b/src/infrastructure/types/baseRepository.d.ts
@@ -1,0 +1,5 @@
+export type BaseCollection = 'users' | 'channels' | 'weekly' | 'monthly' | 'images'
+
+export type DocumentKeys = {
+	[key: string]: string
+}

--- a/src/infrastructure/types/cron.d.ts
+++ b/src/infrastructure/types/cron.d.ts
@@ -1,0 +1,3 @@
+import type { DateTime } from 'luxon'
+
+export type CronTime = string | Date | DateTime

--- a/src/infrastructure/types/firebase.d.ts
+++ b/src/infrastructure/types/firebase.d.ts
@@ -4,3 +4,8 @@ export interface DbHandler {
 	getInstance: () => database.Database
 	disconnect: () => void
 }
+
+export interface DocumentParser<T, U> {
+	toDomain: (document: T) => U
+	toDocument: (entity: U) => T
+}

--- a/src/infrastructure/types/firebase.d.ts
+++ b/src/infrastructure/types/firebase.d.ts
@@ -5,6 +5,15 @@ export interface DbHandler {
 	disconnect: () => void
 }
 
+/**
+ * Represents a document parser that provides functions for converting between a domain entity and a database document.
+ *
+ * @interface DocumentParser
+ * @template T - Database document type.
+ * @template U - Domain entity type.
+ * @property {function} toDomain - Converts a database document to a domain entity.
+ * @property {function} toDocument - Converts a domain entity to a database document.
+ */
 export interface DocumentParser<T, U> {
 	toDomain: (document: T) => U
 	toDocument: (entity: U) => T

--- a/src/infrastructure/types/firebase.d.ts
+++ b/src/infrastructure/types/firebase.d.ts
@@ -23,7 +23,7 @@ export interface FindByUsername extends UserCollection {
 
 export interface FindByUsernameAndChannel {
 	username: string
-	channel: string
+	channelName: string
 }
 
 export interface SaveByUsername extends UserCollection {
@@ -32,5 +32,5 @@ export interface SaveByUsername extends UserCollection {
 
 export interface SaveByUsernameAndChannel {
 	user: User
-	channel: string
+	channelName: string
 }

--- a/src/infrastructure/types/firebase.d.ts
+++ b/src/infrastructure/types/firebase.d.ts
@@ -13,9 +13,12 @@ export interface UserDocumentParser {
 }
 
 // User repository
-export interface FindByUsername {
+export interface UserCollection {
+	collection: 'users' | 'channels' | 'weekly' | 'monthly'
+}
+
+export interface FindByUsername extends UserCollection {
 	username: string
-	collection: 'users' | 'channels'
 }
 
 export interface FindByUsernameAndChannel {
@@ -23,9 +26,8 @@ export interface FindByUsernameAndChannel {
 	channel: string
 }
 
-export interface SaveByUsername {
+export interface SaveByUsername extends UserCollection {
 	user: User
-	collection: 'users' | 'channels'
 }
 
 export interface SaveByUsernameAndChannel {

--- a/src/infrastructure/types/firebase.d.ts
+++ b/src/infrastructure/types/firebase.d.ts
@@ -1,36 +1,6 @@
 import { database } from 'firebase-admin'
-import { UserEntity } from 'domain/types/User'
-import { User } from 'domain/user/User'
 
 export interface DbHandler {
 	getInstance: () => database.Database
 	disconnect: () => void
-}
-
-export interface UserDocumentParser {
-	toDomain: (user: UserEntity) => User
-	toDocument: (user: User) => UserEntity
-}
-
-// User repository
-export interface UserCollection {
-	collection: 'users' | 'channels' | 'weekly' | 'monthly'
-}
-
-export interface FindByUsername extends UserCollection {
-	username: string
-}
-
-export interface FindByUsernameAndChannel {
-	username: string
-	channelName: string
-}
-
-export interface SaveByUsername extends UserCollection {
-	user: User
-}
-
-export interface SaveByUsernameAndChannel {
-	user: User
-	channelName: string
 }

--- a/src/infrastructure/types/imageRepository.d.ts
+++ b/src/infrastructure/types/imageRepository.d.ts
@@ -1,0 +1,5 @@
+import { DocumentParser } from 'infrastructure/types/firebase'
+import { ImageEntity } from 'domain/types/Image'
+import { Image } from 'domain/image/Image'
+
+export type ImageDocumentParser = DocumentParser<ImageEntity, Image>

--- a/src/infrastructure/types/imageRepository.d.ts
+++ b/src/infrastructure/types/imageRepository.d.ts
@@ -3,3 +3,7 @@ import { ImageEntity } from 'domain/types/Image'
 import { Image } from 'domain/image/Image'
 
 export type ImageDocumentParser = DocumentParser<ImageEntity, Image>
+
+export interface ImagesDocument {
+	[key: string]: ImageEntity
+}

--- a/src/infrastructure/types/userRepository.d.ts
+++ b/src/infrastructure/types/userRepository.d.ts
@@ -1,10 +1,8 @@
+import { DocumentParser } from 'infrastructure/types/firebase'
 import { UserEntity } from 'domain/types/User'
 import { User } from 'domain/user/User'
 
-export interface UserDocumentParser {
-	toDomain: (user: UserEntity) => User
-	toDocument: (user: User) => UserEntity
-}
+export type UserDocumentParser = DocumentParser<UserEntity, User>
 
 export interface UserCollection {
 	collection: 'users' | 'channels' | 'weekly' | 'monthly'

--- a/src/infrastructure/types/userRepository.d.ts
+++ b/src/infrastructure/types/userRepository.d.ts
@@ -1,0 +1,29 @@
+import { UserEntity } from 'domain/types/User'
+import { User } from 'domain/user/User'
+
+export interface UserDocumentParser {
+	toDomain: (user: UserEntity) => User
+	toDocument: (user: User) => UserEntity
+}
+
+export interface UserCollection {
+	collection: 'users' | 'channels' | 'weekly' | 'monthly'
+}
+
+export interface FindByUsername extends UserCollection {
+	username: string
+}
+
+export interface FindByUsernameAndChannel {
+	username: string
+	channelName: string
+}
+
+export interface SaveByUsername extends UserCollection {
+	user: User
+}
+
+export interface SaveByUsernameAndChannel {
+	user: User
+	channelName: string
+}

--- a/src/tests/unit/domain/image.test.ts
+++ b/src/tests/unit/domain/image.test.ts
@@ -1,0 +1,80 @@
+// @ts-nocheck
+import { describe, test, expect } from 'vitest'
+import { Image } from 'domain/image/Image'
+
+describe('Instantiate image entity', () => {
+	const VALID_IMAGE = {
+		username: 'afordibot',
+		updatedAt: '04062023',
+		imageUrl:
+			'https://static-cdn.jtvnw.net/jtv_user_pictures/f76406d1-dd3c-4243-a103-e5d3c2cf471f-profile_image-70x70.png',
+	}
+
+	// Type validation
+	test('should be a function', () => {
+		expect(typeof Image).toBe('function')
+	})
+
+	test('should return an object', () => {
+		const user = new Image(VALID_IMAGE)
+		expect(typeof user).toBe('object')
+	})
+
+	// Properties validation
+	test('should return an object with the correct properties', () => {
+		const user = new Image(VALID_IMAGE)
+		expect(user.username).toBe(VALID_IMAGE.username)
+		expect(user.imageUrl).toBe(VALID_IMAGE.imageUrl)
+		expect(user.updatedAt.length).toEqual(8)
+	})
+
+	// Username validation
+	test('should throw an error if username is not a string', () => {
+		expect(() => new Image({ ...VALID_IMAGE, username: 123 })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: {} })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: [] })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: true })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: null })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: undefined })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: 123n })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: Symbol('afordibot') })).toThrow()
+	})
+
+	test('should throw an error if username has length less than 4', () => {
+		expect(() => new Image({ ...VALID_IMAGE, username: '123' })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: '12' })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: '1' })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, username: 'afordibot' })).not.toThrow()
+	})
+
+	// Image URL validation
+	test('should throw an error if imageUrl is not a string', () => {
+		expect(() => new Image({ ...VALID_IMAGE, imageUrl: 123 })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, imageUrl: {} })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, imageUrl: [] })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, imageUrl: true })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, imageUrl: null })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, imageUrl: undefined })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, imageUrl: 123n })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, imageUrl: Symbol('afordibot') })).toThrow()
+	})
+
+	// UpdatedAt validation
+	test('should throw an error if updatedAt is not a string', () => {
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: 123 })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: {} })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: [] })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: true })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: null })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: undefined })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: 123n })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: Symbol('afordibot') })).toThrow()
+	})
+
+	test('should throw an error if updatedAt has length different than 8', () => {
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: '123' })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: '123456789' })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: '1234567' })).toThrow()
+		expect(() => new Image({ ...VALID_IMAGE, updatedAt: '12345678' })).not.toThrow()
+	})
+})

--- a/src/tests/unit/infrastructure/restHelixClient.test.ts
+++ b/src/tests/unit/infrastructure/restHelixClient.test.ts
@@ -20,17 +20,19 @@ describe('Instantiate rest helix client', () => {
 
 	test('should return an object with the expected methods', () => {
 		expect(typeof restHelixClient).toBe('object')
-		expect(typeof restHelixClient.getUserImage).toBe('function')
+		expect(typeof restHelixClient.getUsersData).toBe('function')
 	})
 
-	test('getUserImage method should return expected data', async () => {
+	test('getUsersData method should return expected data', async () => {
 		httpClientMock.post.mockResolvedValue({ access_token: 'test' })
 		httpClientMock.get
 			.mockResolvedValueOnce({ data: [] })
 			.mockResolvedValueOnce({ data: [{ profile_image_url: 'test' }] })
-		expect(await restHelixClient.getUserImage('username')).toEqual(null)
-		expect(await restHelixClient.getUserImage('username')).toEqual('test')
-		expect(httpClientMock.post).toHaveBeenCalledTimes(2)
-		expect(httpClientMock.get).toHaveBeenCalledTimes(2)
+			.mockResolvedValueOnce({ data: [{ profile_image_url: 'test' }, { profile_image_url: 'test' }] })
+		expect(await restHelixClient.getUsersData([])).toEqual([])
+		expect(await restHelixClient.getUsersData(['test'])).toEqual([{ profile_image_url: 'test' }])
+		expect((await restHelixClient.getUsersData(['test', 'test'])).length).toBe(2)
+		expect(httpClientMock.post).toHaveBeenCalledTimes(3)
+		expect(httpClientMock.get).toHaveBeenCalledTimes(3)
 	})
 })

--- a/src/tests/unit/infrastructure/restHelixClient.test.ts
+++ b/src/tests/unit/infrastructure/restHelixClient.test.ts
@@ -26,13 +26,11 @@ describe('Instantiate rest helix client', () => {
 	test('getUsersData method should return expected data', async () => {
 		httpClientMock.post.mockResolvedValue({ access_token: 'test' })
 		httpClientMock.get
-			.mockResolvedValueOnce({ data: [] })
 			.mockResolvedValueOnce({ data: [{ profile_image_url: 'test' }] })
 			.mockResolvedValueOnce({ data: [{ profile_image_url: 'test' }, { profile_image_url: 'test' }] })
-		expect(await restHelixClient.getUsersData([])).toEqual([])
 		expect(await restHelixClient.getUsersData(['test'])).toEqual([{ profile_image_url: 'test' }])
 		expect((await restHelixClient.getUsersData(['test', 'test'])).length).toBe(2)
-		expect(httpClientMock.post).toHaveBeenCalledTimes(3)
-		expect(httpClientMock.get).toHaveBeenCalledTimes(3)
+		expect(httpClientMock.post).toHaveBeenCalledTimes(2)
+		expect(httpClientMock.get).toHaveBeenCalledTimes(2)
 	})
 })

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -1,6 +1,7 @@
 import { AxiosStatic } from 'axios'
 import dayjs from 'dayjs'
 
+import { DateService } from 'domain/services/date'
 import { EmojiService } from 'domain/services/emoji'
 import { UserGeneratorService } from 'domain/services/userGenerator'
 
@@ -27,6 +28,7 @@ export interface Dependencies {
 	dayjs: typeof dayjs
 
 	// Domain services
+	dateService: DateService
 	emojiService: EmojiService
 	userGenerator: UserGeneratorService
 

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -23,6 +23,7 @@ import { GetChannelJolines } from 'application/getChannelJolines'
 import { GetUserJolines } from 'application/getUserJolines'
 import { IncrementAflores } from 'application/incrementAflores'
 import { IncrementJolines } from 'application/incrementJolines'
+import { ResetRanking } from 'application/resetRanking'
 
 export interface Dependencies {
 	// Values
@@ -55,4 +56,5 @@ export interface Dependencies {
 	getUserJolines: GetUserJolines
 	incrementAflores: IncrementAflores
 	incrementJolines: IncrementJolines
+	resetRanking: ResetRanking
 }

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -19,6 +19,7 @@ import { FirebaseHandler } from 'infrastructure/persistance/firebase/dbHandler'
 import { UserDocumentParser } from 'infrastructure/types/userRepository'
 import { UserRepository } from 'infrastructure/persistance/firebase/user/userRepository'
 import { ImageDocumentParser } from 'infrastructure/types/imageRepository'
+import { ImageRepository } from 'infrastructure/persistance/firebase/image/imageRepository'
 
 import { GetChannelAflores } from 'application/getChannelAflores'
 import { GetChannelJolines } from 'application/getChannelJolines'
@@ -54,6 +55,7 @@ export interface Dependencies {
 	userDocumentParser: UserDocumentParser
 	userRepository: UserRepository
 	imageDocumentParser: ImageDocumentParser
+	imageRepository: ImageRepository
 
 	// Use cases
 	getChannelAflores: GetChannelAflores

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -1,4 +1,5 @@
 import { AxiosStatic } from 'axios'
+
 import { EmojiService } from 'domain/services/emoji'
 import { UserGeneratorService } from 'domain/services/userGenerator'
 
@@ -7,9 +8,11 @@ import { AxiosHttpClient } from 'infrastructure/services/axiosHttpClient'
 import { RestHelixClient } from 'infrastructure/services/restHelixClient'
 import { CommandValidator } from 'infrastructure/services/commandValidator'
 import { TextParser } from 'infrastructure/services/textParser'
+
 import { FirebaseHandler } from 'infrastructure/persistance/firebase/dbHandler'
 import { UserDocumentParser } from 'infrastructure/types/userRepository'
 import { UserRepository } from 'infrastructure/persistance/firebase/user/userRepository'
+import { ImageDocumentParser } from 'infrastructure/types/imageRepository'
 
 import { GetChannelAflores } from 'application/getChannelAflores'
 import { GetChannelJolines } from 'application/getChannelJolines'
@@ -18,17 +21,27 @@ import { IncrementAflores } from 'application/incrementAflores'
 import { IncrementJolines } from 'application/incrementJolines'
 
 export interface Dependencies {
+	// Values
 	axios: AxiosStatic
+
+	// Domain services
 	emojiService: EmojiService
 	userGenerator: UserGeneratorService
+
+	// Infrastructure services
 	afordibot: AfordiBot
 	httpClient: AxiosHttpClient
 	restHelixClient: RestHelixClient
 	commandValidator: CommandValidator
 	textParser: TextParser
+
+	// Persistance
 	dbHandler: FirebaseHandler
 	userDocumentParser: UserDocumentParser
 	userRepository: UserRepository
+	imageDocumentParser: ImageDocumentParser
+
+	// Use cases
 	getChannelAflores: GetChannelAflores
 	getChannelJolines: GetChannelJolines
 	getUserJolines: GetUserJolines

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -8,7 +8,7 @@ import { RestHelixClient } from 'infrastructure/services/restHelixClient'
 import { CommandValidator } from 'infrastructure/services/commandValidator'
 import { TextParser } from 'infrastructure/services/textParser'
 import { FirebaseHandler } from 'infrastructure/persistance/firebase/dbHandler'
-import { UserDocumentParser } from 'infrastructure/types/firebase'
+import { UserDocumentParser } from 'infrastructure/types/userRepository'
 import { UserRepository } from 'infrastructure/persistance/firebase/user/userRepository'
 
 import { GetChannelAflores } from 'application/getChannelAflores'

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -1,4 +1,5 @@
 import { AxiosStatic } from 'axios'
+import dayjs from 'dayjs'
 
 import { EmojiService } from 'domain/services/emoji'
 import { UserGeneratorService } from 'domain/services/userGenerator'
@@ -23,6 +24,7 @@ import { IncrementJolines } from 'application/incrementJolines'
 export interface Dependencies {
 	// Values
 	axios: AxiosStatic
+	dayjs: typeof dayjs
 
 	// Domain services
 	emojiService: EmojiService

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -27,6 +27,7 @@ import { GetUserJolines } from 'application/getUserJolines'
 import { IncrementAflores } from 'application/incrementAflores'
 import { IncrementJolines } from 'application/incrementJolines'
 import { ResetRanking } from 'application/resetRanking'
+import { GetUsersImages } from 'application/getUsersImages'
 
 export interface Dependencies {
 	// Values
@@ -64,4 +65,5 @@ export interface Dependencies {
 	incrementAflores: IncrementAflores
 	incrementJolines: IncrementJolines
 	resetRanking: ResetRanking
+	getUsersImages: GetUsersImages
 }

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -1,5 +1,6 @@
 import { AxiosStatic } from 'axios'
 import dayjs from 'dayjs'
+import { CronJob } from 'cron'
 
 import { DateService } from 'domain/services/date'
 import { EmojiService } from 'domain/services/emoji'
@@ -27,6 +28,7 @@ export interface Dependencies {
 	// Values
 	axios: AxiosStatic
 	dayjs: typeof dayjs
+	CronJob: typeof CronJob
 
 	// Domain services
 	dateService: DateService

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -7,6 +7,8 @@ import { EmojiService } from 'domain/services/emoji'
 import { UserGeneratorService } from 'domain/services/userGenerator'
 
 import { AfordiBot } from 'infrastructure/irc/afordibot'
+import { CronJobs } from 'src/infrastructure/cron/cronJobs'
+
 import { AxiosHttpClient } from 'infrastructure/services/axiosHttpClient'
 import { CronService } from 'src/infrastructure/services/cron'
 import { RestHelixClient } from 'infrastructure/services/restHelixClient'
@@ -36,8 +38,11 @@ export interface Dependencies {
 	emojiService: EmojiService
 	userGenerator: UserGeneratorService
 
-	// Infrastructure services
+	// Entry points
 	afordibot: AfordiBot
+	cronJobs: CronJobs
+
+	// Infrastructure services
 	httpClient: AxiosHttpClient
 	cronService: CronService
 	restHelixClient: RestHelixClient

--- a/src/types/container.d.ts
+++ b/src/types/container.d.ts
@@ -7,6 +7,7 @@ import { UserGeneratorService } from 'domain/services/userGenerator'
 
 import { AfordiBot } from 'infrastructure/irc/afordibot'
 import { AxiosHttpClient } from 'infrastructure/services/axiosHttpClient'
+import { CronService } from 'src/infrastructure/services/cron'
 import { RestHelixClient } from 'infrastructure/services/restHelixClient'
 import { CommandValidator } from 'infrastructure/services/commandValidator'
 import { TextParser } from 'infrastructure/services/textParser'
@@ -35,6 +36,7 @@ export interface Dependencies {
 	// Infrastructure services
 	afordibot: AfordiBot
 	httpClient: AxiosHttpClient
+	cronService: CronService
 	restHelixClient: RestHelixClient
 	commandValidator: CommandValidator
 	textParser: TextParser


### PR DESCRIPTION
This PR adds cronjobs services for weekly and monthly ranking resets. Also includes a weekly cronjob to update users images to consume that data in the frontend.